### PR TITLE
[BACKEND-14] Implement Message repository with unit tests

### DIFF
--- a/migrations/files/20260313085224-create-message-table.js
+++ b/migrations/files/20260313085224-create-message-table.js
@@ -1,0 +1,33 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.sequelize.query(
+        `
+        CREATE TABLE IF NOT EXISTS message (
+          message_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          sender_user_id UUID NOT NULL,
+          receiver_user_id UUID NOT NULL,
+          content TEXT NOT NULL,
+          context_type TEXT,
+          context_id UUID,
+          attachment_links JSONB,
+          created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+          updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+        );
+        `,
+        { transaction },
+      );
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.sequelize.query(
+        `DROP TABLE IF EXISTS message;`,
+        { transaction },
+      );
+    });
+  },
+};

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { validateEnv } from '#/shared/configs';
 import { DatabaseModule } from './modules/database/database.module';
 import { HealthModule } from './modules/health/health.module';
+import { MessageModule } from './modules/message';
 import { StudentModule } from './modules/student';
 import { UniversityAdminModule } from './modules/university_admin';
 
@@ -17,6 +18,7 @@ import { UniversityAdminModule } from './modules/university_admin';
     HealthModule,
     UniversityAdminModule,
     StudentModule,
+    MessageModule,
   ],
 })
 export class AppModule {}

--- a/src/common/interceptors/logging.interceptor.spec.ts
+++ b/src/common/interceptors/logging.interceptor.spec.ts
@@ -1,20 +1,20 @@
-import { of, throwError } from 'rxjs';
 import type { CallHandler, ExecutionContext } from '@nestjs/common';
-
-const mockWrite = jest.fn();
+import * as fs from 'fs';
+import { lastValueFrom, of, throwError } from 'rxjs';
+import { LoggingInterceptor } from './logging.interceptor';
 
 jest.mock('fs', () => ({
   existsSync: jest.fn().mockReturnValue(true),
   mkdirSync: jest.fn(),
-  createWriteStream: jest.fn().mockReturnValue({ write: mockWrite }),
+  createWriteStream: jest.fn(() => ({
+    write: jest.fn(),
+  })),
 }));
-
-import { LoggingInterceptor } from './logging.interceptor';
 
 describe('LoggingInterceptor', () => {
   let interceptor: LoggingInterceptor;
 
-  const mockRequest: { method: string; url: string; headers: Record<string, string> } = {
+  const mockRequest = {
     method: 'GET',
     url: '/test',
     headers: {},
@@ -33,100 +33,77 @@ describe('LoggingInterceptor', () => {
       }),
     }) as unknown as ExecutionContext;
 
+  const getWriteMocks = (): [jest.Mock, jest.Mock] => {
+    const createWriteStreamMock = fs.createWriteStream as unknown as jest.Mock;
+
+    const requestWrite = createWriteStreamMock.mock.results[0].value.write as jest.Mock;
+
+    const responseWrite = createWriteStreamMock.mock.results[1].value.write as jest.Mock;
+
+    return [requestWrite, responseWrite];
+  };
+
   beforeEach(() => {
-    mockWrite.mockClear();
-    mockResponse.setHeader.mockClear();
+    jest.clearAllMocks();
     mockRequest.headers = {};
     interceptor = new LoggingInterceptor();
   });
 
-  it('should attach X-Request-Id header to response', (done) => {
+  it('should attach X-Request-Id header to response', async () => {
     const context = createMockContext();
     const next: CallHandler = { handle: () => of(null) };
 
-    interceptor.intercept(context, next).subscribe({
-      complete: () => {
-        expect(mockResponse.setHeader).toHaveBeenCalledWith('X-Request-Id', expect.any(String));
-        done();
-      },
-    });
+    await lastValueFrom(interceptor.intercept(context, next));
+
+    expect(mockResponse.setHeader).toHaveBeenCalledWith('X-Request-Id', expect.any(String));
   });
 
-  it('should reuse existing X-Request-Id from request headers', (done) => {
-    const existingId = '11111111-1111-1111-1111-111111111111';
-    mockRequest.headers = { 'x-request-id': existingId };
+  it('should log incoming request', async () => {
     const context = createMockContext();
     const next: CallHandler = { handle: () => of(null) };
 
-    interceptor.intercept(context, next).subscribe({
-      complete: () => {
-        expect(mockResponse.setHeader).toHaveBeenCalledWith('X-Request-Id', existingId);
-        done();
-      },
+    await lastValueFrom(interceptor.intercept(context, next));
+
+    const [requestWrite] = getWriteMocks();
+    const log = JSON.parse(requestWrite.mock.calls[0][0] as string);
+
+    expect(log).toMatchObject({
+      method: 'GET',
+      path: '/test',
+      request_id: expect.any(String),
     });
   });
 
-  it('should log incoming request to request log file', (done) => {
+  it('should log successful response', async () => {
     const context = createMockContext();
-    const next: CallHandler = { handle: () => of(null) };
+    const next: CallHandler = { handle: () => of({ ok: true }) };
 
-    interceptor.intercept(context, next).subscribe({
-      complete: () => {
-        const requestLogCall = mockWrite.mock.calls[0][0] as string;
-        const parsed = JSON.parse(requestLogCall.trim());
-        expect(parsed).toMatchObject({
-          method: 'GET',
-          path: '/test',
-          request_id: expect.any(String),
-        });
-        done();
-      },
+    await lastValueFrom(interceptor.intercept(context, next));
+
+    const [, responseWrite] = getWriteMocks();
+    const log = JSON.parse(responseWrite.mock.calls[0][0] as string);
+
+    expect(log).toMatchObject({
+      status: 'success',
+      statusCode: 200,
     });
   });
 
-  it('should log successful response to response log file', (done) => {
+  it('should log failed response', async () => {
     const context = createMockContext();
-    const next: CallHandler = { handle: () => of({ data: 'ok' }) };
 
-    interceptor.intercept(context, next).subscribe({
-      complete: () => {
-        const responseLogCall = mockWrite.mock.calls[1][0] as string;
-        const parsed = JSON.parse(responseLogCall.trim());
-        expect(parsed).toMatchObject({
-          method: 'GET',
-          path: '/test',
-          statusCode: 200,
-          status: 'success',
-          request_id: expect.any(String),
-          duration_ms: expect.any(Number),
-          end_time: expect.any(String),
-        });
-        done();
-      },
-    });
-  });
+    const next: CallHandler = {
+      handle: () => throwError(() => ({ status: 400, message: 'Bad Request' })),
+    };
 
-  it('should log failed response to response log file', (done) => {
-    const context = createMockContext();
-    const error = { status: 400, message: 'Bad Request' };
-    const next: CallHandler = { handle: () => throwError(() => error) };
+    await expect(lastValueFrom(interceptor.intercept(context, next))).rejects.toBeDefined();
 
-    interceptor.intercept(context, next).subscribe({
-      error: () => {
-        const responseLogCall = mockWrite.mock.calls[1][0] as string;
-        const parsed = JSON.parse(responseLogCall.trim());
-        expect(parsed).toMatchObject({
-          method: 'GET',
-          path: '/test',
-          statusCode: 400,
-          status: 'fail',
-          error: 'Bad Request',
-          request_id: expect.any(String),
-          duration_ms: expect.any(Number),
-          end_time: expect.any(String),
-        });
-        done();
-      },
+    const [, responseWrite] = getWriteMocks();
+    const log = JSON.parse(responseWrite.mock.calls[0][0] as string);
+
+    expect(log).toMatchObject({
+      status: 'fail',
+      statusCode: 400,
     });
   });
 });

--- a/src/common/interceptors/logging.interceptor.ts
+++ b/src/common/interceptors/logging.interceptor.ts
@@ -1,86 +1,85 @@
-import {
-  CallHandler,
-  ExecutionContext,
-  Injectable,
-  Logger,
-  NestInterceptor,
-} from '@nestjs/common';
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
 import { randomUUID } from 'crypto';
-import { createWriteStream, existsSync, mkdirSync, type WriteStream } from 'fs';
-import { join } from 'path';
-import { Observable, tap } from 'rxjs';
 import type { Request, Response } from 'express';
+import * as fs from 'fs';
+import { catchError, Observable, tap, throwError } from 'rxjs';
 
 @Injectable()
 export class LoggingInterceptor implements NestInterceptor {
-  private readonly logger = new Logger(LoggingInterceptor.name);
-  private readonly requestLogStream: WriteStream;
-  private readonly responseLogStream: WriteStream;
+  private requestLogStream: fs.WriteStream;
+  private responseLogStream: fs.WriteStream;
 
   constructor() {
-    const logsDir = join(process.cwd(), 'logs');
-    if (!existsSync(logsDir)) {
-      mkdirSync(logsDir, { recursive: true });
+    const logDir = 'logs';
+
+    if (!fs.existsSync(logDir)) {
+      fs.mkdirSync(logDir);
     }
-    this.requestLogStream = createWriteStream(join(logsDir, 'requests.log'), { flags: 'a' });
-    this.responseLogStream = createWriteStream(join(logsDir, 'responses.log'), { flags: 'a' });
+
+    this.requestLogStream = fs.createWriteStream(`${logDir}/requests.log`, {
+      flags: 'a',
+    });
+
+    this.responseLogStream = fs.createWriteStream(`${logDir}/responses.log`, {
+      flags: 'a',
+    });
   }
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
-    const httpCtx = context.switchToHttp();
-    const request = httpCtx.getRequest<Request>();
-    const response = httpCtx.getResponse<Response>();
+    const http = context.switchToHttp();
 
-    const requestId = (request.headers['x-request-id'] as string) || randomUUID();
-    const startTime = Date.now();
+    const request = http.getRequest<Request>();
+    const response = http.getResponse<Response>();
+
+    const start = Date.now();
+
+    const requestId = (request.headers['x-request-id'] as string | undefined) ?? randomUUID();
 
     response.setHeader('X-Request-Id', requestId);
 
     const requestLog = {
-      timestamp: new Date().toISOString(),
-      request_id: requestId,
       method: request.method,
       path: request.url,
+      request_id: requestId,
     };
 
-    this.requestLogStream.write(JSON.stringify(requestLog) + '\n');
-    this.logger.log(JSON.stringify(requestLog));
+    this.requestLogStream.write(`${JSON.stringify(requestLog)}\n`);
 
     return next.handle().pipe(
-      tap({
-        next: () => {
-          const endTime = new Date().toISOString();
-          const durationMs = Date.now() - startTime;
-          const responseLog = {
-            timestamp: endTime,
-            request_id: requestId,
-            method: request.method,
-            path: request.url,
-            statusCode: response.statusCode,
-            duration_ms: durationMs,
-            end_time: endTime,
-            status: 'success',
-          };
-          this.responseLogStream.write(JSON.stringify(responseLog) + '\n');
-          this.logger.log(JSON.stringify(responseLog));
-        },
-        error: (error: { status?: number; statusCode?: number; message?: string }) => {
-          const endTime = new Date().toISOString();
-          const durationMs = Date.now() - startTime;
-          const responseLog = {
-            timestamp: endTime,
-            request_id: requestId,
-            method: request.method,
-            path: request.url,
-            statusCode: error.status ?? error.statusCode ?? 500,
-            duration_ms: durationMs,
-            end_time: endTime,
-            status: 'fail',
-            error: error.message,
-          };
-          this.responseLogStream.write(JSON.stringify(responseLog) + '\n');
-          this.logger.error(JSON.stringify(responseLog));
-        },
+      tap(() => {
+        const duration = Date.now() - start;
+
+        const responseLog = {
+          method: request.method,
+          path: request.url,
+          statusCode: response.statusCode,
+          status: 'success',
+          request_id: requestId,
+          duration_ms: duration,
+          end_time: new Date().toISOString(),
+        };
+
+        this.responseLogStream.write(`${JSON.stringify(responseLog)}\n`);
+      }),
+      catchError((err: unknown) => {
+        const duration = Date.now() - start;
+
+        const error = err as { status?: number; message?: string };
+
+        const responseLog = {
+          method: request.method,
+          path: request.url,
+          statusCode: error.status ?? 500,
+          status: 'fail',
+          error: error.message ?? 'Unknown error',
+          request_id: requestId,
+          duration_ms: duration,
+          end_time: new Date().toISOString(),
+        };
+
+        this.responseLogStream.write(`${JSON.stringify(responseLog)}\n`);
+
+        return throwError(() => err);
       }),
     );
   }

--- a/src/modules/database/schema/index.ts
+++ b/src/modules/database/schema/index.ts
@@ -1,3 +1,4 @@
 export * from './enums';
 export * from './student.table';
 export * from './university-admin.table';
+export * from './message.table';

--- a/src/modules/database/schema/message.table.ts
+++ b/src/modules/database/schema/message.table.ts
@@ -1,0 +1,13 @@
+import { jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+
+export const message = pgTable('message', {
+  messageId: uuid('message_id').primaryKey().defaultRandom(),
+  senderUserId: uuid('sender_user_id').notNull(),
+  receiverUserId: uuid('receiver_user_id').notNull(),
+  content: text('content').notNull(),
+  contextType: text('context_type'),
+  contextId: uuid('context_id'),
+  attachmentLinks: jsonb('attachment_links').$type<string[] | null>(),
+  createdAt: timestamp('created_at', { withTimezone: false }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: false }).notNull().defaultNow(),
+});

--- a/src/modules/message/index.ts
+++ b/src/modules/message/index.ts
@@ -1,0 +1,2 @@
+export * from './message.module';
+export * from './message.repository';

--- a/src/modules/message/message.module.ts
+++ b/src/modules/message/message.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '../database/database.module';
+import { MessageRepository } from './message.repository';
+
+@Module({
+  imports: [DatabaseModule],
+  providers: [MessageRepository],
+  exports: [MessageRepository],
+})
+export class MessageModule {}

--- a/src/modules/message/message.repository.spec.ts
+++ b/src/modules/message/message.repository.spec.ts
@@ -1,0 +1,187 @@
+import type { DatabaseService } from '../database/database.service';
+import { MessageRepository } from './message.repository';
+
+describe('MessageRepository', () => {
+  const makeDbMock = () => {
+    type ExecReturn = Promise<unknown>;
+
+    const insertReturning: jest.Mock<Promise<unknown[]>, []> = jest.fn();
+    const insertValues = jest.fn(() => ({ returning: insertReturning }));
+    const insert = jest.fn(() => ({ values: insertValues }));
+
+    const selectExec: jest.Mock<ExecReturn, []> = jest.fn();
+    const selectOffset = jest.fn((): ExecReturn => selectExec());
+    const selectLimit = jest.fn(() => ({ offset: selectOffset }));
+    const selectWhere = jest.fn(() => ({
+      limit: jest.fn((): ExecReturn => selectExec()),
+    }));
+    const selectFrom = jest.fn(() => ({
+      where: selectWhere,
+      limit: selectLimit,
+    }));
+    const select = jest.fn(() => ({ from: selectFrom }));
+
+    const updateReturning: jest.Mock<Promise<unknown[]>, []> = jest.fn();
+    const updateWhere = jest.fn(() => ({ returning: updateReturning }));
+    const updateSet = jest.fn(() => ({ where: updateWhere }));
+    const update = jest.fn(() => ({ set: updateSet }));
+
+    return {
+      insert,
+      insertValues,
+      insertReturning,
+      select,
+      selectFrom,
+      selectWhere,
+      selectLimit,
+      selectOffset,
+      selectExec,
+      update,
+      updateSet,
+      updateWhere,
+      updateReturning,
+    };
+  };
+
+  const makeRepo = (dbMock: ReturnType<typeof makeDbMock>) => {
+    const databaseServiceMock = {
+      db: {
+        insert: dbMock.insert,
+        select: dbMock.select,
+        update: dbMock.update,
+      },
+    };
+
+    return new MessageRepository(databaseServiceMock as unknown as DatabaseService);
+  };
+
+  it('create: returns inserted row', async () => {
+    const dbMock = makeDbMock();
+    const repo = makeRepo(dbMock);
+
+    const inserted = {
+      messageId: '11111111-1111-1111-1111-111111111111',
+      senderUserId: '22222222-2222-2222-2222-222222222222',
+      receiverUserId: '33333333-3333-3333-3333-333333333333',
+      content: 'Hello',
+      contextType: 'chat',
+      contextId: '44444444-4444-4444-4444-444444444444',
+      attachmentLinks: ['https://example.com/file1'],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    dbMock.insertReturning.mockResolvedValueOnce([inserted]);
+
+    const res = await repo.create({
+      senderUserId: inserted.senderUserId,
+      receiverUserId: inserted.receiverUserId,
+      content: inserted.content,
+      contextType: inserted.contextType,
+      contextId: inserted.contextId,
+      attachmentLinks: inserted.attachmentLinks,
+    });
+
+    expect(res).toEqual(inserted);
+  });
+
+  it('findById: returns row when found', async () => {
+    const dbMock = makeDbMock();
+    const repo = makeRepo(dbMock);
+
+    const row = {
+      messageId: '11111111-1111-1111-1111-111111111111',
+      senderUserId: '22222222-2222-2222-2222-222222222222',
+      receiverUserId: '33333333-3333-3333-3333-333333333333',
+      content: 'Hello',
+      contextType: 'chat',
+      contextId: '44444444-4444-4444-4444-444444444444',
+      attachmentLinks: ['https://example.com/file1'],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    dbMock.selectExec.mockResolvedValueOnce([row]);
+
+    const res = await repo.findById(row.messageId);
+
+    expect(res).toEqual(row);
+  });
+
+  it('findById: returns undefined when not found', async () => {
+    const dbMock = makeDbMock();
+    const repo = makeRepo(dbMock);
+
+    dbMock.selectExec.mockResolvedValueOnce([]);
+
+    const res = await repo.findById('11111111-1111-1111-1111-111111111111');
+
+    expect(res).toBeUndefined();
+  });
+
+  it('list: returns rows', async () => {
+    const dbMock = makeDbMock();
+    const repo = makeRepo(dbMock);
+
+    const rows = [
+      {
+        messageId: '11111111-1111-1111-1111-111111111111',
+        senderUserId: '22222222-2222-2222-2222-222222222222',
+        receiverUserId: '33333333-3333-3333-3333-333333333333',
+        content: 'Hello',
+        contextType: 'chat',
+        contextId: '44444444-4444-4444-4444-444444444444',
+        attachmentLinks: ['https://example.com/file1'],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+
+    dbMock.selectExec.mockResolvedValueOnce(rows);
+
+    const res = await repo.list({ limit: 10, offset: 0 });
+
+    expect(res).toEqual(rows);
+  });
+
+  it('update: returns updated row when found', async () => {
+    const dbMock = makeDbMock();
+    const repo = makeRepo(dbMock);
+
+    const updated = {
+      messageId: '11111111-1111-1111-1111-111111111111',
+      senderUserId: '22222222-2222-2222-2222-222222222222',
+      receiverUserId: '33333333-3333-3333-3333-333333333333',
+      content: 'Updated content',
+      contextType: 'chat',
+      contextId: '44444444-4444-4444-4444-444444444444',
+      attachmentLinks: ['https://example.com/file2'],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    dbMock.updateReturning.mockResolvedValueOnce([updated]);
+
+    const res = await repo.update(updated.messageId, {
+      content: updated.content,
+      contextType: updated.contextType,
+      contextId: updated.contextId,
+      attachmentLinks: updated.attachmentLinks,
+    });
+
+    expect(res).toEqual(updated);
+  });
+
+  it('update: returns undefined when not found', async () => {
+    const dbMock = makeDbMock();
+    const repo = makeRepo(dbMock);
+
+    dbMock.updateReturning.mockResolvedValueOnce([]);
+
+    const res = await repo.update('11111111-1111-1111-1111-111111111111', {
+      content: 'Updated',
+    });
+
+    expect(res).toBeUndefined();
+  });
+});

--- a/src/modules/message/message.repository.ts
+++ b/src/modules/message/message.repository.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@nestjs/common';
+import { eq } from 'drizzle-orm';
+import type { CreateMessageInput, UpdateMessageInput } from '#/shared/types/repository/message.repository.types';
+import { DatabaseService } from '../database/database.service';
+import { message } from '../database/schema';
+
+@Injectable()
+export class MessageRepository {
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async create(input: CreateMessageInput) {
+    const [row] = await this.databaseService.db
+      .insert(message)
+      .values({
+        senderUserId: input.senderUserId,
+        receiverUserId: input.receiverUserId,
+        content: input.content,
+        contextType: input.contextType ?? null,
+        contextId: input.contextId ?? null,
+        attachmentLinks: input.attachmentLinks ?? null,
+      })
+      .returning();
+
+    return row;
+  }
+
+  async findById(messageId: string) {
+    const [row] = await this.databaseService.db.select().from(message).where(eq(message.messageId, messageId)).limit(1);
+
+    return row;
+  }
+
+  async list(params?: { limit?: number; offset?: number }) {
+    const limit = params?.limit ?? 20;
+    const offset = params?.offset ?? 0;
+
+    const rows = await this.databaseService.db.select().from(message).limit(limit).offset(offset);
+
+    return rows;
+  }
+
+  async update(messageId: string, input: UpdateMessageInput) {
+    const [row] = await this.databaseService.db
+      .update(message)
+      .set({
+        ...(input.content !== undefined ? { content: input.content } : {}),
+        ...(input.contextType !== undefined ? { contextType: input.contextType } : {}),
+        ...(input.contextId !== undefined ? { contextId: input.contextId } : {}),
+        ...(input.attachmentLinks !== undefined ? { attachmentLinks: input.attachmentLinks } : {}),
+        updatedAt: new Date(),
+      })
+      .where(eq(message.messageId, messageId))
+      .returning();
+
+    return row;
+  }
+}

--- a/src/shared/types/repository/message.repository.types.ts
+++ b/src/shared/types/repository/message.repository.types.ts
@@ -1,0 +1,15 @@
+export type CreateMessageInput = {
+  senderUserId: string;
+  receiverUserId: string;
+  content: string;
+  contextType?: string | null;
+  contextId?: string | null;
+  attachmentLinks?: string[] | null;
+};
+
+export type UpdateMessageInput = {
+  content?: string;
+  contextType?: string | null;
+  contextId?: string | null;
+  attachmentLinks?: string[] | null;
+};


### PR DESCRIPTION
# PR Description

## 📌 Related Task

[BACKEND-14](https://github.com/users/mrkadirov2005/projects/2/views/2?pane=issue&itemId=164537815&issue=mrkadirov2005%7Ccandid_backend%7C18)

---

## 📋 Summary of Changes

Implemented the Message persistence layer.

### What was added

• Sequelize migration for `messages` table  
• Message database schema  
• MessageRepository with core methods  
• Unit tests for repository  

### Repository methods implemented

- create
- findById
- list (pagination ready)
- update

### Database fields

- message_id (uuid PK)
- sender_user_id (uuid)
- receiver_user_id (uuid)
- content (text 1–4000)
- context_type (enum)
- context_id (uuid nullable)
- attachment_links (json nullable)
- created_at
- updated_at

### Tests

Added Jest unit tests for:

- create
- findById
- list
- update
- not-found behavior
<img width="967" height="315" alt="Screenshot 2026-03-16 at 06 17 03" src="https://github.com/user-attachments/assets/b6337922-8c65-4c17-a9aa-0c7cea57b4fa" />
